### PR TITLE
fix: improper usage of number type in dtos & handling bigints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@nestjs/common": "^11.1.6",
         "@nestjs/core": "^11.0.1",
-        "@nestjs/mapped-types": "*",
+        "@nestjs/mapped-types": "^2.1.0",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/schedule": "^6.0.1",
         "@prisma/client": "^6.16.2",
@@ -295,6 +295,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1024,6 +1025,7 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -2772,6 +2774,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2956,6 +2959,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.6.tgz",
       "integrity": "sha512-krKwLLcFmeuKDqngG2N/RuZHCs2ycsKcxWIDgcm7i1lf3sQ0iG03ci+DsP/r3FcT/eJDFsIHnKtNta2LIi7PzQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.0.0",
         "iterare": "1.2.1",
@@ -2988,6 +2992,7 @@
       "integrity": "sha512-siWX7UDgErisW18VTeJA+x+/tpNZrJewjTBsRPF3JVxuWRuAB1kRoiJcxHgln8Lb5UY9NdvklITR84DUEXD0Cg==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -3048,6 +3053,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.6.tgz",
       "integrity": "sha512-HErwPmKnk+loTq8qzu1up+k7FC6Kqa8x6lJ4cDw77KnTxLzsCaPt+jBvOq6UfICmfqcqCCf3dKXg+aObQp+kIQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.1.0",
@@ -3128,7 +3134,6 @@
       "integrity": "sha512-SdhaKdko6dpsSr0DldkESItVrnPYB1NS2NpShCSX5lc7SSQmLZt5Mug6t2xbiuVWEVDLZSuIAoQyYVBYp0dR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-glob": "3.3.1"
       }
@@ -3139,7 +3144,6 @@
       "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -3157,7 +3161,6 @@
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -3679,6 +3682,7 @@
       "integrity": "sha512-fYDQA9e6yTNmA13TLVSA+WMQRc5Bn/c0EUBditUHNfMMxN7M82c38b1kEggVE3pLpZ0FwkwJkUEKMiOi52JXFA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@babel/generator": "^7.26.5",
         "@babel/parser": "^7.26.7",
@@ -3836,6 +3840,7 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3969,6 +3974,7 @@
       "integrity": "sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -4046,8 +4052,7 @@
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.3.tgz",
       "integrity": "sha512-7bcUmDyS6PN3EuD9SlGGOxM77F8WLVsrwkxyWxKnxzmXoequ6c7741QBrANq6htVRGOITJ7z72mTP6Z4XyuG+Q==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -4072,6 +4077,7 @@
       "integrity": "sha512-EGDAOGX+uwwekcS0iyxVDmRV9HX6FLSM5kzrAToLTsr9OWCIKG/y3lQheCq18yZ5Xh78rRKJiEpP0ZaCs4ryOQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
         "@typescript-eslint/scope-manager": "8.44.0",
@@ -4112,6 +4118,7 @@
       "integrity": "sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.44.0",
         "@typescript-eslint/types": "8.44.0",
@@ -4794,6 +4801,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4843,6 +4851,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5506,6 +5515,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -7006,6 +7016,7 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9691,6 +9702,7 @@
       "integrity": "sha512-Ry+p2+NLk6u8Agh5yVqELfUJvRfV51hhVBRIB5yZPY7mU0DGBmOuFG5GebZbMbm86cdQNK0fhJuDX8/1YorISQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.1.3",
         "@jest/types": "30.0.5",
@@ -10676,8 +10688,7 @@
       "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.18.tgz",
       "integrity": "sha512-k0pdkX8DXHqVrby7yJ23WBcHMCX1lhwvX/Uazh0vf3wfGQa0qDIyRB2Z2C01JREGGt8Assfwl1yZduq59OjXXQ==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -12282,6 +12293,7 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -12462,6 +12474,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "6.16.2",
         "@prisma/engines": "6.16.2"
@@ -12677,7 +12690,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -12937,6 +12951,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -14005,6 +14020,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -14392,6 +14408,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -14617,6 +14634,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14862,7 +14880,6 @@
       "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.10"
       }
@@ -15004,7 +15021,6 @@
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -15023,7 +15039,6 @@
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3"
       },
@@ -15037,7 +15052,6 @@
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -15052,7 +15066,6 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -15062,8 +15075,7 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/webpack/node_modules/mime-db": {
       "version": "1.52.0",
@@ -15071,7 +15083,6 @@
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -15082,7 +15093,6 @@
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -15096,7 +15106,6 @@
       "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@nestjs/common": "^11.1.6",
     "@nestjs/core": "^11.0.1",
-    "@nestjs/mapped-types": "*",
+    "@nestjs/mapped-types": "^2.1.0",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/schedule": "^6.0.1",
     "@prisma/client": "^6.16.2",

--- a/src/github/github-pull-request.interface.ts
+++ b/src/github/github-pull-request.interface.ts
@@ -1,17 +1,17 @@
 import type { PullRequestStatus } from "@prisma/client";
 
 export interface GithubPullRequest {
-  id: number;
+  id: bigint;
   title: string;
   state: PullRequestStatus;
   merged_at: string | null;
   updated_at: string;
   created_at: string;
   user: {
-    id: number;
+    id: bigint;
   };
   assignees: {
-    id: number | undefined;
+    id: bigint | null;
   }[];
-  requested_reviewers: { id: number | undefined }[];
+  requested_reviewers: { id: bigint | null }[];
 }

--- a/src/github/pr-fetcher.ts
+++ b/src/github/pr-fetcher.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unnecessary-type-conversion */
+// it is necessary, as lint is wrong, and we are actually converting a number to a BIGINT.
 import { PrismaClient, PullRequestStatus, UserRole } from "@prisma/client";
 import { CreatePullRequestDto } from "src/pull-request/dto/create-pull-request.dto";
 import { UpdatePullRequestDto } from "src/pull-request/dto/update-pull-request.dto";
@@ -9,7 +11,7 @@ import { GithubPullRequest } from "./github-pull-request.interface";
 
 @Injectable()
 export class PRFetcherService {
-  @Cron(CronExpression.EVERY_10_MINUTES)
+  @Cron(CronExpression.EVERY_MINUTE)
   async getAllPRs() {
     const github_token = process.env.GITHUB_PERSONAL_TOKEN;
     const owner = process.env.GITHUB_REPO_OWNER;
@@ -17,7 +19,6 @@ export class PRFetcherService {
     if (owner === undefined || repo === undefined) {
       throw new Error("define repository in .env");
     }
-    console.warn(`https://api.github.com/repos/${owner}/${repo}/pulls`);
     let page = 1;
     const perPage = "100";
     let allPRs: GithubPullRequest[] = [];
@@ -97,7 +98,7 @@ export class PRFetcherService {
         const assigneeId = pr.assignees[0]?.id;
         if (
           assigneeId != null &&
-          !assignees.some((a) => a.githubId === assigneeId)
+          !assignees.some((a) => a.githubId === BigInt(assigneeId))
         ) {
           console.warn(`${String(pr.id)} has an unregistered assignee`);
           continue;
@@ -109,7 +110,7 @@ export class PRFetcherService {
         const reviewerId = pr.requested_reviewers[0]?.id;
         if (
           reviewerId != null &&
-          !reviewers.some((r) => r.githubId === reviewerId)
+          !reviewers.some((r) => r.githubId === BigInt(reviewerId))
         ) {
           console.warn(`${String(pr.id)} has a unregistered reviewer`);
           continue;

--- a/src/github/pr-fetcher.ts
+++ b/src/github/pr-fetcher.ts
@@ -15,7 +15,7 @@ export class PRFetcherService {
     const owner = process.env.GITHUB_REPO_OWNER;
     const repo = process.env.GITHUB_REPO_NAME;
     if (owner === undefined || repo === undefined) {
-      throw new Error("define reposity in .env");
+      throw new Error("define repository in .env");
     }
     console.warn(`https://api.github.com/repos/${owner}/${repo}/pulls`);
     let page = 1;
@@ -97,7 +97,7 @@ export class PRFetcherService {
         const assigneeId = pr.assignees[0]?.id;
         if (
           assigneeId != null &&
-          !assignees.some((a) => Number(a.githubId) === assigneeId)
+          !assignees.some((a) => a.githubId === assigneeId)
         ) {
           console.warn(`${String(pr.id)} has an unregistered assignee`);
           continue;
@@ -109,7 +109,7 @@ export class PRFetcherService {
         const reviewerId = pr.requested_reviewers[0]?.id;
         if (
           reviewerId != null &&
-          !reviewers.some((r) => Number(r.githubId) === reviewerId)
+          !reviewers.some((r) => r.githubId === reviewerId)
         ) {
           console.warn(`${String(pr.id)} has a unregistered reviewer`);
           continue;
@@ -131,7 +131,7 @@ export class PRFetcherService {
             githubCreatedAt: new Date(pr.created_at),
             githubUpdatedAt: new Date(pr.updated_at),
             githubMergedAt:
-              pr.merged_at === null ? undefined : new Date(pr.merged_at),
+              pr.merged_at === null ? null : new Date(pr.merged_at),
             assigneeId,
             status: this.mapGitHubStateToPrisma(pr.state),
             reviewerId: pr.requested_reviewers[0]?.id,

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,12 @@ import { NestFactory } from "@nestjs/core";
 
 import { AppModule } from "./app.module";
 
+// THIS IS A CRUCIAL WORKAROUND FOR SERIALIZATION ISSUE WITH BIGINTs
+// eslint-disable-next-line no-extend-native
+BigInt.prototype.toJSON = function (this: bigint): string {
+  return this.toString();
+};
+
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   await app.listen(process.env.PORT ?? 3000);

--- a/src/pull-request/dto/create-pull-request.dto.ts
+++ b/src/pull-request/dto/create-pull-request.dto.ts
@@ -1,13 +1,13 @@
 import type { PullRequestStatus } from "@prisma/client";
 
 export class CreatePullRequestDto {
-  id: number;
+  id: bigint;
   taskId: number;
-  assigneeId?: number; // github id
-  createdById: number; // github id
-  reviewerId?: number; // github id
+  assigneeId: bigint | null; // github id
+  createdById: bigint; // github id
+  reviewerId: bigint | null; // github id
   githubCreatedAt: Date;
   githubUpdatedAt: Date;
-  githubMergedAt?: Date;
+  githubMergedAt?: Date | null;
   status: PullRequestStatus;
 }

--- a/src/pull-request/dto/update-pull-request.dto.ts
+++ b/src/pull-request/dto/update-pull-request.dto.ts
@@ -5,10 +5,10 @@ import { PartialType } from "@nestjs/mapped-types";
 import { CreatePullRequestDto } from "./create-pull-request.dto";
 
 export class UpdatePullRequestDto extends PartialType(CreatePullRequestDto) {
-  taskId: number;
-  assigneeId?: number; // github id
-  reviewerId?: number; // github id
+  taskId?: number;
+  assigneeId?: bigint | null; // github id
+  reviewerId?: bigint | null; // github id
   githubUpdatedAt?: Date;
-  githubMergedAt?: Date;
+  githubMergedAt?: Date | null;
   status?: PullRequestStatus;
 }

--- a/src/types/bigint.d.ts
+++ b/src/types/bigint.d.ts
@@ -1,0 +1,3 @@
+interface BigInt {
+  toJSON: (this: BigInt) => string;
+}

--- a/src/user/dto/create-user.dto.ts
+++ b/src/user/dto/create-user.dto.ts
@@ -1,8 +1,8 @@
 import type { UserRole } from "@prisma/client";
 
 export class CreateUserDto {
-  githubId: number;
-  assignedReviewerId?: number;
+  githubId: bigint;
+  assignedReviewerId?: bigint | null;
   username: string;
   name: string;
   lastName: string;

--- a/src/user/dto/get-user.dto.ts
+++ b/src/user/dto/get-user.dto.ts
@@ -1,9 +1,9 @@
 import type { UserRole } from "@prisma/client";
 
 export class GetUserDto {
-  githubId: number;
-  assignedReviewerId: number;
-  assignedReviewerUsername: string;
+  githubId: bigint;
+  assignedReviewerId: bigint | null;
+  assignedReviewerUsername: string | null;
   username: string;
   name: string;
   lastName: string;

--- a/src/user/dto/update-user.dto.ts
+++ b/src/user/dto/update-user.dto.ts
@@ -5,7 +5,7 @@ import { PartialType } from "@nestjs/mapped-types";
 import { CreateUserDto } from "./create-user.dto";
 
 export class UpdateUserDto extends PartialType(CreateUserDto) {
-  assignedReviewerId?: number;
+  assignedReviewerId?: bigint | null;
   username?: string;
   name?: string;
   lastName?: string;


### PR DESCRIPTION
When working on crud services I noticed problems with bigints, which made it impossible to return data. The fix was simple, complex and improper at the same time. Below there is a list of changes:

- Usage of a proper data types in DTO's and interfaces (ids are bigints as it is declared in schema, some may be null [not necessarily undefined]
- Removal of unnecessary data type conversions (`src/github/pr-fetcher.ts`)
- Modification of a bigint data type (`src/types/bigint.d.ts`)
- Override of a default bigint behavior when converting to JSON (`src/main.ts`). This required suppression of lint.

The changes in `pr-fetcher.ts` have not been tested due to removal of a test repository, thus I kindly ask @Liseu1 to check whether these changes are non braking. For certain I can assure, that the rest of the changes are in fact working.